### PR TITLE
feat:  Transforms cleanup

### DIFF
--- a/API.md
+++ b/API.md
@@ -3152,7 +3152,7 @@ Examines construct.
 ##### `apply` <a name="apply" id="@michanto/cdk-orchestration.transforms.JsonParser.apply"></a>
 
 ```typescript
-public apply(template: string): any
+public apply(template: string): {[ key: string ]: any}
 ```
 
 ###### `template`<sup>Required</sup> <a name="template" id="@michanto/cdk-orchestration.transforms.JsonParser.apply.parameter.template"></a>
@@ -4837,7 +4837,7 @@ Examines construct.
 ##### `apply` <a name="apply" id="@michanto/cdk-orchestration.transforms.Parser.apply"></a>
 
 ```typescript
-public apply(template: string): any
+public apply(template: string): {[ key: string ]: any}
 ```
 
 ###### `template`<sup>Required</sup> <a name="template" id="@michanto/cdk-orchestration.transforms.Parser.apply.parameter.template"></a>
@@ -9595,7 +9595,7 @@ Examines construct.
 ##### `apply` <a name="apply" id="@michanto/cdk-orchestration.transforms.YamlParser.apply"></a>
 
 ```typescript
-public apply(template: string): any
+public apply(template: string): {[ key: string ]: any}
 ```
 
 ###### `template`<sup>Required</sup> <a name="template" id="@michanto/cdk-orchestration.transforms.YamlParser.apply.parameter.template"></a>

--- a/src/orchestration/handlers/step_function_execute.ts
+++ b/src/orchestration/handlers/step_function_execute.ts
@@ -56,9 +56,7 @@ export function startsWithOneOf(searchStrings: string[]): (string: string) => bo
 }
 
 function log(message: Record<string, any>) {
-  if (process.env.LogLevel) {
-    console.log(JSON.stringify(message));
-  }
+  logger?.log(JSON.stringify(message));
 }
 
 export const startStepFunction = async (event: any, context: any) => {

--- a/src/transforms/cfn_transform.ts
+++ b/src/transforms/cfn_transform.ts
@@ -31,8 +31,6 @@ export abstract class CfnTransform extends Construct implements ICfnTransform {
 
   public constructor(scope: Construct, readonly id: string) {
     super(scope, id);
-    // Calls TransformHost.hook on the host Stack and/or CfnElement to ensure there is a host for the Transform.
-    TransformHost.ensureHosted(this);
     CFN_TRANSFORM_RTTI.addRtti(this);
     this.host = TransformHost.of(this);
   }

--- a/src/transforms/parser.ts
+++ b/src/transforms/parser.ts
@@ -1,7 +1,7 @@
 import { Construct } from 'constructs';
 import { parse as yamlParse } from 'yaml';
 import { ImportOrders } from './import_orders';
-import { TransformBase } from './transform';
+import { CfTemplateType, TransformBase } from './transform';
 
 /**
  * Base class for JsonParser and YamlParser transforms.
@@ -15,7 +15,7 @@ export abstract class Parser extends TransformBase {
     return ImportOrders.PARSER;
   }
 
-  abstract apply(template: string): any;
+  abstract apply(template: string): CfTemplateType;
 
   /**
    * @internal
@@ -34,7 +34,7 @@ export class YamlParser extends Parser {
     super(scope, id);
   }
 
-  apply(template: string): any {
+  apply(template: string): CfTemplateType {
     return yamlParse(template);
   }
 }
@@ -48,7 +48,7 @@ export class JsonParser extends Parser {
     super(scope, id);
   }
 
-  apply(template: string): any {
+  apply(template: string): CfTemplateType {
     return JSON.parse(template);
   }
 }

--- a/src/transforms/private/transform_rtti.ts
+++ b/src/transforms/private/transform_rtti.ts
@@ -44,7 +44,7 @@ export const TRANSFORM_CONSTRUCT_HOST = new ConstructHost({
 export const TRANSFORM_HOST_OF = new ConstructService({
   servicePropertyName: `${TRANSFORM_HOST_RTTI.props.servicePropertyName}Cache`,
   factory: (c: Construct) => {
-    return TRANSFORM_HOST_RTTI.searchUp(c)?.scope;
+    return TRANSFORM_HOST_RTTI.searchUp(c, Stack.isStack)?.scope;
   },
 });
 

--- a/src/transforms/transform.ts
+++ b/src/transforms/transform.ts
@@ -62,13 +62,7 @@ export abstract class TransformBase extends Construct implements IInspectable {
     }
 
     // If parent is an L1 construct, this will work because the constructor called ensureHosted.
-    let host = TransformHost.of(base);
-    if (host) {
-      return host;
-    }
-
-    // Default parent is always the scope.
-    return base;
+    return TransformHost.of(base);
   }
 
   /** The L1 Shim transform attached to an L2 TransformBase. */
@@ -100,6 +94,11 @@ export abstract class TransformBase extends Construct implements IInspectable {
     // This will make any antecedent CfnElement or Stack a TransformHost.
     TransformHost.ensureHosted(scope);
     let parent = ImportOrder.findImportOrder(this.shimParent, this.order);
+    if (scope.node.path.startsWith(parent.node.path)) {
+      // If this Transform is already under the parent, use this transform as the parent.
+      // It makes the tree neater.
+      parent = this;
+    }
     // Id for the transform shim
     let shimId = `${id}Shim${parent.node.children.length}`;
     this.cfnTransform = new TransformBase.CfnTransformShim(parent, shimId, this);

--- a/src/transforms/transform_host.ts
+++ b/src/transforms/transform_host.ts
@@ -42,6 +42,10 @@ export class TransformHost {
    * Not being able to do this may not be fatal, so we don't throw.
    */
   public static ensureHosted(scope: Construct) {
+    let ensured = TRANSFORM_HOST_OF.get(scope);
+    if (ensured) {
+      return ensured as Construct;
+    }
     // If this was created under an L1, hook the L1.
     let hostElt = new CfnElementUtilities().cfnElementHost(scope);
     if (hostElt) {
@@ -54,7 +58,7 @@ export class TransformHost {
     }
 
     let found = TRANSFORM_HOST_OF.searchSelfOrCreate(scope);
-    return ConstructService.serviceOf(found);
+    return ConstructService.serviceOf(found) as Construct;
   }
 
   /**

--- a/test/transforms/transform.test.ts
+++ b/test/transforms/transform.test.ts
@@ -72,15 +72,15 @@ describe('Transform tests.', () => {
 
   it('Transform applied to Stack works', () => {
     let stack = new Stack();
-    new BucketNameTransform(stack, 'BucketName', 'my_bucket');
-    expect(CfnTransform.isCfnTransform(stack.node.children[1])).toBeTruthy();
+    let transform = new BucketNameTransform(stack, 'BucketName', 'my_bucket');
+    expect(CfnTransform.isCfnTransform(transform.node.children[0])).toBeTruthy();
   });
 
   it('Transform applied to Order directly works', () => {
     let stack = new Stack();
     let order = new ImportOrder(stack, ImportOrders.TRANSFORMS);
-    new BucketNameTransform(order, 'BucketName', 'my_bucket');
-    expect(CfnTransform.isCfnTransform(order.node.children[1])).toBeTruthy();
+    let transform = new BucketNameTransform(order, 'BucketName', 'my_bucket');
+    expect(CfnTransform.isCfnTransform(transform.node.children[0])).toBeTruthy();
   });
 
   it('Transform applied to L1 Order works', () => {


### PR DESCRIPTION
Fixes #
- Parser return type matches Transform.
- StepFunction task handler logging cleanup.
- Only call ensureHosted when necessary.
- CfnTransform created as a child of TransformBase whenever possible.
- ensureHosted is faster on subsequent calls.
- Fixed tests to match new behavior.