### PR TITLE
fix:  Move esbuild tests to cdk-orchestration-examples

### DIFF
--- a/test/aws-lambda-nodejs/inline_nodejs_function.test.ts
+++ b/test/aws-lambda-nodejs/inline_nodejs_function.test.ts
@@ -150,7 +150,7 @@ describe('InlineNodeJsFunction tests', () => {
 
   test.each([
     undefined,
-    // MinifyEngine.ES_BUILD,
+    // MinifyEngine.ES_BUILD, Note:  EsBuild tests moved to cdk-orchestration-examples.
     MinifyEngine.SIMPLE,
     MinifyEngine.NONE,
   ])('InlineNodejsFunction all minify', (engine) => {
@@ -188,21 +188,6 @@ describe('InlineNodeJsFunction tests', () => {
         },
       },
     });
-  });
-
-  test.skip('InlineNodejsFunction no esbuild', () => {
-    // GIVEN
-    const stack = new Stack();
-
-    // WHEN
-    jest.mock('esbuild', () => {
-      throw new Error();
-    });
-
-    // THEN
-    expect(() => new MyInlineFunction(stack, 'MyInlineFunction', {
-      minifyEngine: MinifyEngine.ES_BUILD,
-    })).toThrow();
   });
 
   test('InlineNodejsFunction LAMBDA_NODEJS_USE_LATEST_RUNTIME enabled', () => {

--- a/test/aws-lambda-nodejs/inline_nodejs_function.test.ts
+++ b/test/aws-lambda-nodejs/inline_nodejs_function.test.ts
@@ -4,6 +4,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { InlineNodejsFunction, InlineNodejsFunctionProps, MinifyEngine } from '../../src/aws-lambda-nodejs';
 import { Logger, LoggingAspect } from '../../src/core';
+import { TemplateCapture } from '../../src/transforms';
 
 const LAMBDA_PATH = `${__dirname}/../../lib/aws-lambda-nodejs/private/test_lambdas`;
 describe('InlineNodeJsFunction tests', () => {
@@ -161,6 +162,7 @@ describe('InlineNodeJsFunction tests', () => {
     let fn = new MyInlineFunction(stack, 'MyInlineFunction', {
       minifyEngine: engine,
     });
+    let capture = new TemplateCapture(fn, 'Capture');
 
     // THEN
     let inspector = new TreeInspector();
@@ -172,6 +174,9 @@ describe('InlineNodeJsFunction tests', () => {
     }
 
     let template = Template.fromStack(stack).toJSON();
+    let codeSize = capture.template.Resources.MyInlineFunction9974A7D0.Properties.Code.ZipFile.length;
+    let engineName = engine == undefined ? 'undefined' : MinifyEngine[engine];
+    console.log(`Engine ${engineName} produced code of size ${codeSize}`);
     expect(template).toMatchObject({
       Resources: {
         MyInlineFunction9974A7D0: {

--- a/test/aws-lambda-nodejs/inline_nodejs_function.test.ts
+++ b/test/aws-lambda-nodejs/inline_nodejs_function.test.ts
@@ -195,6 +195,17 @@ describe('InlineNodeJsFunction tests', () => {
     });
   });
 
+
+  test('InlineNodejsFunction no esbuild', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // THEN
+    expect(() => new MyInlineFunction(stack, 'MyInlineFunction', {
+      minifyEngine: MinifyEngine.ES_BUILD,
+    })).toThrow();
+  });
+
   test('InlineNodejsFunction LAMBDA_NODEJS_USE_LATEST_RUNTIME enabled', () => {
     // GIVEN
     const stack = new Stack();


### PR DESCRIPTION
Fixes #
No esbuild here but have it there.  So move tests.